### PR TITLE
Support Tower.app in a path with spaces

### DIFF
--- a/net.cjlucas.alfred.tower/open_repo.bash
+++ b/net.cjlucas.alfred.tower/open_repo.bash
@@ -11,4 +11,4 @@ GITTOWER_PATH="$TOWER_PATH/Contents/MacOS/gittower"
 # $1 is set by the "Run Script" action
 args="$1"
 
-eval $GITTOWER_PATH $args
+eval "'$GITTOWER_PATH'" $args


### PR DESCRIPTION
fixes calling Tower.app in a path including spaces
