### PR TITLE
Remove check for "filereferenceurl" key.

### DIFF
--- a/net.cjlucas.alfred.tower/lib/tower_bookmarks_parser.rb
+++ b/net.cjlucas.alfred.tower/lib/tower_bookmarks_parser.rb
@@ -82,7 +82,7 @@ module TowerWorkflow
     end
 
     def valid_repository?(hash)
-      hash.has_key?('filereferenceurl') && hash.has_key?('fileurl')
+      hash.has_key?('fileurl')
     end
 
     def folder?(hash)


### PR DESCRIPTION
It no longer exists in the bookmarks file as of Tower 2.5 beta. Closes #14.